### PR TITLE
Update the blog link present in userprofile_sync.adoc

### DIFF
--- a/content/modules/userprofile/pages/userprofile_sync.adoc
+++ b/content/modules/userprofile/pages/userprofile_sync.adoc
@@ -571,6 +571,6 @@ Check out the following links for further details
 
 * link:https://blog.couchbase.com/data-replication-couchbase-mobile/[Overview of Replication Protocol 2.0]
 
-* link:https://blog.couchbase.com/couchbase-mobile-docker/[Installing Sync Gateway using Docker]
+* link:https://blog.couchbase.com/using-docker-with-couchbase-mobile//[Installing Sync Gateway using Docker]
 
 


### PR DESCRIPTION
Updated the blog link "https://blog.couchbase.com/couchbase-mobile-docker/" to "https://blog.couchbase.com/using-docker-with-couchbase-mobile/". The link present on the page leads to the "Page not found".